### PR TITLE
Multiline strings

### DIFF
--- a/glexp.cabal
+++ b/glexp.cabal
@@ -57,7 +57,6 @@ library
                      , linear
                      , primitive
                      , random
-                     , raw-strings-qq
                      , vector
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Engine/Particle.hs
+++ b/src/Engine/Particle.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE MultilineStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 module Engine.Particle
   ( Program

--- a/src/Engine/Particle.hs
+++ b/src/Engine/Particle.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultilineStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 module Engine.Particle
@@ -32,54 +33,53 @@ import qualified Data.Vector.Storable as V
 import qualified Data.Vector.Storable.Mutable as VM
 import qualified Engine.Utils as Utils
 import qualified Linear
-import qualified Text.RawString.QQ as QQ
 
 vertexShaderSrc :: BS.ByteString
 vertexShaderSrc = BS.pack
-  [QQ.r|
-    #version 330 core
+  """
+  #version 330 core
 
-    in vec2 position;
-    in mat4 modelView;
-    in vec4 texOffsets;
-    in float blendFactor;
+  in vec2 position;
+  in mat4 modelView;
+  in vec4 texOffsets;
+  in float blendFactor;
 
-    out vec2 texCoord1;
-    out vec2 texCoord2;
-    out float blend;
+  out vec2 texCoord1;
+  out vec2 texCoord2;
+  out float blend;
 
-    uniform mat4 projection;
-    uniform float numberOfRows;
+  uniform mat4 projection;
+  uniform float numberOfRows;
 
-    void main() {
-      vec2 texCoord = position + vec2(0.5, 0.5);
-      texCoord.y = 1.0 - texCoord.y;
-      texCoord /= numberOfRows;
-      texCoord1 = texCoord + texOffsets.xy;
-      texCoord2 = texCoord + texOffsets.zw;
-      blend = blendFactor;
+  void main() {
+    vec2 texCoord = position + vec2(0.5, 0.5);
+    texCoord.y = 1.0 - texCoord.y;
+    texCoord /= numberOfRows;
+    texCoord1 = texCoord + texOffsets.xy;
+    texCoord2 = texCoord + texOffsets.zw;
+    blend = blendFactor;
 
-      gl_Position = projection * modelView * vec4(position, 0.0, 1.0);
-    }
-  |]
+    gl_Position = projection * modelView * vec4(position, 0.0, 1.0);
+  }
+  """
 
 fragmentShaderSrc :: BS.ByteString
 fragmentShaderSrc = BS.pack
-  [QQ.r|
-    #version 330 core
-    in vec2 texCoord1;
-    in vec2 texCoord2;
-    in float blend;
-    out vec4 color;
+  """
+  #version 330 core
+  in vec2 texCoord1;
+  in vec2 texCoord2;
+  in float blend;
+  out vec4 color;
 
-    uniform sampler2D tex;
+  uniform sampler2D tex;
 
-    void main() {
-      vec4 color1 = texture(tex, texCoord1);
-      vec4 color2 = texture(tex, texCoord2);
-      color = mix(color1, color2, blend);
-    }
-  |]
+  void main() {
+    vec4 color1 = texture(tex, texCoord1);
+    vec4 color2 = texture(tex, texCoord2);
+    color = mix(color1, color2, blend);
+  }
+  """
 
 gravity :: GLfloat
 gravity = -50

--- a/src/Engine/Skybox.hs
+++ b/src/Engine/Skybox.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultilineStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 module Engine.Skybox
@@ -26,44 +27,43 @@ import Graphics.GL.Types
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Vector.Storable as V
 import qualified Linear
-import qualified Text.RawString.QQ as QQ
 
 vertexShaderSrc :: ByteString
 vertexShaderSrc = BS.pack
-  [QQ.r|
-    #version 330 core
-    layout (location = 0) in vec3 position;
-    out vec3 v_texCoord;
-    uniform mat4 projection;
-    uniform mat4 view;
+  """
+  #version 330 core
+  layout (location = 0) in vec3 position;
+  out vec3 v_texCoord;
+  uniform mat4 projection;
+  uniform mat4 view;
 
-    void main() {
-      v_texCoord = position;
-      vec4 pos = projection * view * vec4(position, 1.0);
-      gl_Position = pos.xyww;
-    }
-  |]
+  void main() {
+    v_texCoord = position;
+    vec4 pos = projection * view * vec4(position, 1.0);
+    gl_Position = pos.xyww;
+  }
+  """
 
 fragmentShaderSrc :: ByteString
 fragmentShaderSrc = BS.pack
-  [QQ.r|
-    #version 330 core
-    in vec3 v_texCoord;
-    out vec4 color;
+  """
+  #version 330 core
+  in vec3 v_texCoord;
+  out vec4 color;
 
-    uniform samplerCube skybox;
-    uniform vec3 skyColor;
+  uniform samplerCube skybox;
+  uniform vec3 skyColor;
 
-    const float lowerLimit = 0.0;
-    const float upperLimit = 40.0 / 100.0;
+  const float lowerLimit = 0.0;
+  const float upperLimit = 40.0 / 100.0;
 
-    void main() {
-      vec4 finalColor = texture(skybox, v_texCoord);
-      float factor = (v_texCoord.y - lowerLimit) / (upperLimit - lowerLimit);
-      factor = clamp(factor, 0.0, 1.0);
-      color = mix(vec4(skyColor, 1.0), finalColor, factor);
-    }
-  |]
+  void main() {
+    vec4 finalColor = texture(skybox, v_texCoord);
+    float factor = (v_texCoord.y - lowerLimit) / (upperLimit - lowerLimit);
+    factor = clamp(factor, 0.0, 1.0);
+    color = mix(vec4(skyColor, 1.0), finalColor, factor);
+  }
+  """
 
 vertexBuffer :: V.Vector GLfloat
 vertexBuffer = V.fromList

--- a/src/Engine/Skybox.hs
+++ b/src/Engine/Skybox.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE MultilineStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 module Engine.Skybox
   ( Program

--- a/src/Engine/Terrain/Terrain.hs
+++ b/src/Engine/Terrain/Terrain.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE MultilineStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 module Engine.Terrain.Terrain
   ( Program

--- a/src/Engine/TexturedModel.hs
+++ b/src/Engine/TexturedModel.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultilineStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 module Engine.TexturedModel
@@ -24,105 +25,104 @@ import Graphics.GL.Types
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Vector.Storable as V
 import qualified Linear
-import qualified Text.RawString.QQ as QQ
 
 vertexShaderSrc :: Int -> ByteString
 vertexShaderSrc maxLights = BS.pack (shaderHeader maxLights) <> BS.pack
-  [QQ.r|
-    in vec3 position;
-    in vec2 texCoord;
-    in vec3 normal;
+  """
+  in vec3 position;
+  in vec2 texCoord;
+  in vec3 normal;
 
-    out vec2 v_texCoord;
-    out vec3 surfaceNormal;
-    out vec3 lightVec[NUM_LIGHTS];
-    out vec3 cameraVec;
-    out float visibility;
+  out vec2 v_texCoord;
+  out vec3 surfaceNormal;
+  out vec3 lightVec[NUM_LIGHTS];
+  out vec3 cameraVec;
+  out float visibility;
 
-    uniform mat4 model;      // Transformation of the model
-    uniform mat4 view;       // Transformation of the camera
-    uniform mat4 projection; // Clipping coordinates outside FOV
-    uniform vec3 lightPosition[NUM_LIGHTS];
-    uniform float useFakeLighting;
-    uniform float numberOfRows;
-    uniform vec2 offset;
-    uniform vec4 clipPlane;
+  uniform mat4 model;      // Transformation of the model
+  uniform mat4 view;       // Transformation of the camera
+  uniform mat4 projection; // Clipping coordinates outside FOV
+  uniform vec3 lightPosition[NUM_LIGHTS];
+  uniform float useFakeLighting;
+  uniform float numberOfRows;
+  uniform vec2 offset;
+  uniform vec4 clipPlane;
 
-    const float density = 0.007;
-    const float gradient = 1.5;
+  const float density = 0.007;
+  const float gradient = 1.5;
 
-    void main() {
-      vec4 worldPosition = model * vec4(position, 1.0);
-      gl_ClipDistance[0] = dot(worldPosition, clipPlane);
-      vec4 positionRelativeToCam = view * worldPosition;
-      gl_Position = projection * positionRelativeToCam;
-      v_texCoord = texCoord / numberOfRows + offset;
+  void main() {
+    vec4 worldPosition = model * vec4(position, 1.0);
+    gl_ClipDistance[0] = dot(worldPosition, clipPlane);
+    vec4 positionRelativeToCam = view * worldPosition;
+    gl_Position = projection * positionRelativeToCam;
+    v_texCoord = texCoord / numberOfRows + offset;
 
-      vec3 actualNormal = normal;
-      if (useFakeLighting > 0.5) {
-        actualNormal = vec3(0.0, 1.0, 0.0);
-      }
-
-      surfaceNormal = (model * vec4(actualNormal, 0.0)).xyz;
-      for (int i = 0; i < NUM_LIGHTS; i++) {
-        lightVec[i] = lightPosition[i] - worldPosition.xyz;
-      }
-      cameraVec = (inverse(view) * vec4(0.0, 0.0, 0.0, 1.0)).xyz - worldPosition.xyz;
-
-      float distance = length(positionRelativeToCam.xyz);
-      visibility = clamp(exp(-pow(distance * density, gradient)), 0.0, 1.0);
+    vec3 actualNormal = normal;
+    if (useFakeLighting > 0.5) {
+      actualNormal = vec3(0.0, 1.0, 0.0);
     }
-  |]
+
+    surfaceNormal = (model * vec4(actualNormal, 0.0)).xyz;
+    for (int i = 0; i < NUM_LIGHTS; i++) {
+      lightVec[i] = lightPosition[i] - worldPosition.xyz;
+    }
+    cameraVec = (inverse(view) * vec4(0.0, 0.0, 0.0, 1.0)).xyz - worldPosition.xyz;
+
+    float distance = length(positionRelativeToCam.xyz);
+    visibility = clamp(exp(-pow(distance * density, gradient)), 0.0, 1.0);
+  }
+  """
 
 fragmentShaderSrc :: Int -> ByteString
 fragmentShaderSrc maxLights = BS.pack (shaderHeader maxLights) <> BS.pack
-  [QQ.r|
-    in vec2 v_texCoord;
-    in vec3 surfaceNormal;
-    in vec3 lightVec[NUM_LIGHTS];
-    in vec3 cameraVec;
-    in float visibility;
+  """
+  in vec2 v_texCoord;
+  in vec3 surfaceNormal;
+  in vec3 lightVec[NUM_LIGHTS];
+  in vec3 cameraVec;
+  in float visibility;
 
-    uniform sampler2D myTexture;
-    uniform vec3 lightColor[NUM_LIGHTS];
-    uniform vec3 attenuation[NUM_LIGHTS];
-    uniform float shineDamper;
-    uniform float reflectivity;
-    uniform vec3 skyColor;
+  uniform sampler2D myTexture;
+  uniform vec3 lightColor[NUM_LIGHTS];
+  uniform vec3 attenuation[NUM_LIGHTS];
+  uniform float shineDamper;
+  uniform float reflectivity;
+  uniform vec3 skyColor;
 
-    out vec4 color;
+  out vec4 color;
 
-    void main() {
-      vec3 unitNormal = normalize(surfaceNormal);
-      vec3 unitCameraVec = normalize(cameraVec);
+  void main() {
+    vec3 unitNormal = normalize(surfaceNormal);
+    vec3 unitCameraVec = normalize(cameraVec);
 
-      vec3 totalDiffuse = vec3(0.0);
-      vec3 totalSpecular = vec3(0.0);
-      for (int i = 0; i < NUM_LIGHTS; i++) {
-        float distance = length(lightVec[i]);
-        float attenuationFactor = attenuation[i].x +
-                                  attenuation[i].y * distance +
-                                  attenuation[i].z * distance * distance;
-        vec3 unitLightVec = normalize(lightVec[i]);
-        float brightness = max(dot(unitNormal, unitLightVec), 0.0);
-        vec3 reflectedLightVec = reflect(-unitLightVec, unitNormal);
-        float specularFactor = max(dot(reflectedLightVec, unitCameraVec), 0.0);
-        float dampedFactor = pow(specularFactor, shineDamper);
+    vec3 totalDiffuse = vec3(0.0);
+    vec3 totalSpecular = vec3(0.0);
+    for (int i = 0; i < NUM_LIGHTS; i++) {
+      float distance = length(lightVec[i]);
+      float attenuationFactor = attenuation[i].x +
+                                attenuation[i].y * distance +
+                                attenuation[i].z * distance * distance;
+      vec3 unitLightVec = normalize(lightVec[i]);
+      float brightness = max(dot(unitNormal, unitLightVec), 0.0);
+      vec3 reflectedLightVec = reflect(-unitLightVec, unitNormal);
+      float specularFactor = max(dot(reflectedLightVec, unitCameraVec), 0.0);
+      float dampedFactor = pow(specularFactor, shineDamper);
 
-        totalDiffuse += brightness * lightColor[i] / attenuationFactor;
-        totalSpecular += dampedFactor * reflectivity * lightColor[i] / attenuationFactor;
-      }
-      totalDiffuse = max(totalDiffuse, 0.2);
-
-      vec4 textureColor = texture(myTexture, v_texCoord);
-      if (textureColor.a < 0.5) {
-        discard;
-      }
-
-      color = vec4(totalDiffuse, 1.0) * textureColor + vec4(totalSpecular, 1.0);
-      color = mix(vec4(skyColor, 1.0), color, visibility);
+      totalDiffuse += brightness * lightColor[i] / attenuationFactor;
+      totalSpecular += dampedFactor * reflectivity * lightColor[i] / attenuationFactor;
     }
-  |]
+    totalDiffuse = max(totalDiffuse, 0.2);
+
+    vec4 textureColor = texture(myTexture, v_texCoord);
+    if (textureColor.a < 0.5) {
+      discard;
+    }
+
+    color = vec4(totalDiffuse, 1.0) * textureColor + vec4(totalSpecular, 1.0);
+    color = mix(vec4(skyColor, 1.0), color, visibility);
+  }
+  """
 
 data Program = Program
   { program             :: {-# UNPACK #-} !GLuint

--- a/src/Engine/TexturedModel.hs
+++ b/src/Engine/TexturedModel.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE MultilineStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 module Engine.TexturedModel
   ( Program

--- a/src/Engine/Water/Water.hs
+++ b/src/Engine/Water/Water.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE MultilineStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 module Engine.Water.Water
   ( Program


### PR DESCRIPTION
GHC 9.12 added the `MultilineStrings` extension, which means that quasiquote package `raw-strings-qq` is no longer necessary. For the sake of reducing unnecessary dependencies which can cause breakages, this PR removes the package and changes all uses to use multiline string literals.